### PR TITLE
修复一个 todo.list 的解析 bug

### DIFF
--- a/spider.py
+++ b/spider.py
@@ -75,7 +75,7 @@ def getACList():
 
 def getTodoList():
 	text = readFile('todo.list')
-	text = re.sub(r'#[\s\S]*?\n', '', text)
+	text = re.sub(r'#[\s\S]*?$', '', text, flags=re.MULTILINE)
 	find = re.split(r'[\s]', text)
 	prob = []
 	added = []


### PR DESCRIPTION
如果 todo.list 不以换行结尾，那么解析器不会跳过最后一行的注释，例如 #12 

fix #12 
